### PR TITLE
Enhanced structs to allow more go-ish marshaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ import (
 )
 
 func main() {
-	ip_data, err := gothreat.IPReport("4.2.2.1")
+	ipData, err := gothreat.IPReport("4.2.2.1")
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf("Permalink: %s\n", ip_data.Permalink)
+	fmt.Printf("Permalink: %s\n", ipData.Permalink)
 	fmt.Printf("DNS Resolutions:\n")
-	for _, resolve := range ip_data.Resolutions {
-		fmt.Printf("\t%s -> %s\n", resolve["last_resolved"], resolve["domain"])
+	for _, resolve := range ipData.Resolutions {
+		fmt.Printf("\t%v -> %v\n", resolve.LastResolved, resolve.Domain)
 	}
 	fmt.Printf("References:\n")
-	for _, reference := range ip_data.References {
+	for _, reference := range ipData.References {
 		fmt.Printf("\t%s\n", reference)
 	}
 	fmt.Printf("Hashes:\n")
-	for _, hash := range ip_data.Hashes {
+	for _, hash := range ipData.Hashes {
 		fmt.Printf("\t%s\n", hash)
 	}
 }

--- a/av.go
+++ b/av.go
@@ -1,29 +1,33 @@
 package gothreat
 
 import (
-    "encoding/json"
+	"encoding/json"
 )
 
 type AntiVirusData struct {
-    Permalink string
-    References []string
-    Hashes []string
-    ResponseCode int
+	ResponseCode string   `json:"response_code"`
+	Md5          string   `json:"md5"`
+	Sha1         string   `json:"sha1"`
+	Scans        []string `json:"scans"`
+	Ips          []string `json:"ips"`
+	Domains      []string `json:"domains"`
+	References   []string `json:"references"`
+	Permalink    string   `json:"permalink"`
 }
 
 func AntiVirusReportRaw(av string) ([]byte, error) {
-    return process_report("antivirus", av)
+	return process_report("antivirus", av)
 }
 
-func AntiVirusReport(av string) (AntiVirusData, error){
-    var av_data AntiVirusData
-    data, err := AntiVirusReportRaw(av)
+func AntiVirusReport(av string) (AntiVirusData, error) {
+	var avData AntiVirusData
+	data, err := AntiVirusReportRaw(av)
 
-    if err != nil {
-        return av_data, err
-    }
+	if err != nil {
+		return avData, err
+	}
 
-    json.Unmarshal(data, &av_data)
+	json.Unmarshal(data, &avData)
 
-    return av_data, nil
+	return avData, nil
 }

--- a/domain.go
+++ b/domain.go
@@ -1,32 +1,35 @@
 package gothreat
 
 import (
-    "encoding/json"
+	"encoding/json"
 )
 
 type DomainData struct {
-    Permalink string
-    References []string
-    Emails []string
-    Subdomains []string
-    Hashes []string
-    Resolutions []map[string]string
-    ResponseCode int
+	ResponseCode string `json:"response_code"`
+	Resolutions  []struct {
+		LastResolved string `json:"last_resolved"`
+		IPAddress    string `json:"ip_address"`
+	} `json:"resolutions"`
+	Hashes     []string `json:"hashes"`
+	Emails     []string `json:"emails"`
+	Subdomains []string `json:"subdomains"`
+	References []string `json:"references"`
+	Permalink  string   `json:"permalink"`
 }
 
 func DomainReportRaw(domain string) ([]byte, error) {
-    return process_report("domain", domain)
+	return process_report("domain", domain)
 }
 
-func DomainReport(domain string) (DomainData, error){
-    var domain_data DomainData
-    data, err := DomainReportRaw(domain)
+func DomainReport(domain string) (DomainData, error) {
+	var domainData DomainData
+	data, err := DomainReportRaw(domain)
 
-    if err != nil {
-        return domain_data, err
-    }
+	if err != nil {
+		return domainData, err
+	}
 
-    json.Unmarshal(data, &domain_data)
+	json.Unmarshal(data, &domainData)
 
-    return domain_data, nil
+	return domainData, nil
 }

--- a/email.go
+++ b/email.go
@@ -1,29 +1,29 @@
 package gothreat
 
 import (
-    "encoding/json"
+	"encoding/json"
 )
 
 type EmailData struct {
-    Permalink string
-    References []string
-    Domains []string
-    ResponseCode int
+	ResponseCode string   `json:"response_code"`
+	Domains      []string `json:"domains"`
+	References   []string `json:"references"`
+	Permalink    string   `json:"permalink"`
 }
 
 func EmailReportRaw(email string) ([]byte, error) {
-    return process_report("email", email)
+	return process_report("email", email)
 }
 
-func EmailReport(email string) (EmailData, error){
-    var email_data EmailData
-    data, err := EmailReportRaw(email)
+func EmailReport(email string) (EmailData, error) {
+	var emailData EmailData
+	data, err := EmailReportRaw(email)
 
-    if err != nil {
-        return email_data, err
-    }
+	if err != nil {
+		return emailData, err
+	}
 
-    json.Unmarshal(data, &email_data)
+	json.Unmarshal(data, &emailData)
 
-    return email_data, nil
+	return emailData, nil
 }

--- a/ip.go
+++ b/ip.go
@@ -1,30 +1,33 @@
 package gothreat
 
 import (
-    "encoding/json"
+	"encoding/json"
 )
 
 type IPData struct {
-    Permalink string
-    Response_code int
-    References []string
-    Resolutions []map[string]string
-    Hashes []string
+	ResponseCode string `json:"response_code"`
+	Resolutions  []struct {
+		LastResolved string `json:"last_resolved"`
+		Domain       string `json:"domain"`
+	} `json:"resolutions"`
+	Hashes     []string `json:"hashes"`
+	References []string `json:"references"`
+	Permalink  string   `json:"permalink"`
 }
 
-func IPReportRaw(ipaddr string) ([]byte, error){
-    return process_report("ip", ipaddr)
+func IPReportRaw(ipaddr string) ([]byte, error) {
+	return process_report("ip", ipaddr)
 }
 
-func IPReport(ipaddr string) (IPData, error){
-    var ip_data IPData
-    data, err := IPReportRaw(ipaddr)
+func IPReport(ipaddr string) (IPData, error) {
+	var ipData IPData
+	data, err := IPReportRaw(ipaddr)
 
-    if err != nil {
-        return ip_data, err
-    }
+	if err != nil {
+		return ipData, err
+	}
 
-    json.Unmarshal(data, &ip_data)
+	json.Unmarshal(data, &ipData)
 
-    return ip_data, nil
+	return ipData, nil
 }


### PR DESCRIPTION
I have some more changes to the way go can marshal the returned json into go data structures:
- with strict marshaling we will be able to iterate over the values in a cleaner way (see changes to the example in Readme)
- variables with underscore should be omitted in go
